### PR TITLE
Removing unused imports

### DIFF
--- a/client/src/components/ui/sonner.tsx
+++ b/client/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()

--- a/client/src/features/dashboard/components/app-sidebar.tsx
+++ b/client/src/features/dashboard/components/app-sidebar.tsx
@@ -1,11 +1,8 @@
 import * as React from "react"
 import {
-  AudioWaveform,
   Book,
   Bot,
-  Command,
   Frame,
-  GalleryVerticalEnd,
   LayoutDashboard,
   LogOut,
   Mail,

--- a/client/src/features/dashboard/components/nav-footer.tsx
+++ b/client/src/features/dashboard/components/nav-footer.tsx
@@ -3,7 +3,6 @@ import { type LucideIcon } from "lucide-react"
 
 import {
     SidebarGroup,
-    SidebarGroupContent,
     SidebarMenu,
     SidebarMenuButton,
     SidebarMenuItem,


### PR DESCRIPTION
This PR removes unused imports that blocks deployment

## Summary by Sourcery

Clean up unused imports in UI and dashboard components to unblock deployment and update sonner import to use a type-only import for ToasterProps

Bug Fixes:
- Remove unused imports blocking deployment

Enhancements:
- Convert ToasterProps import to a type-only import from sonner